### PR TITLE
feat(opl3lpt): omit adlib detection and direct call to OPL3LPT

### DIFF
--- a/FASTDOOM/ns_sbmus.c
+++ b/FASTDOOM/ns_sbmus.c
@@ -123,31 +123,6 @@ static int AL_MaxMidiChannel = 16;
    Sends data to the Adlib using a specified port.
 ---------------------------------------------------------------------*/
 
-void AL_SendOutputToPort(
-    int port,
-    int reg,
-    int data)
-
-{
-   int delay;
-
-   outp(port, reg);
-
-   for (delay = 6; delay > 0; delay--)
-   //   for( delay = 2; delay > 0 ; delay-- )
-   {
-      inp(port);
-   }
-
-   outp(port + 1, data);
-
-   //   for( delay = 35; delay > 0 ; delay-- )
-   for (delay = 27; delay > 0; delay--)
-   //   for( delay = 2; delay > 0 ; delay-- )
-   {
-      inp(port);
-   }
-}
 
 void AL_SendOutputToPort_OPL2LPT(int port, int reg, int data)
 {
@@ -224,6 +199,16 @@ void AL_SendOutputToPort_OPL3LPT(int port, int reg, int data)
    {
       inp(lpt_ctrl);
    }
+}
+
+
+void AL_SendOutputToPort(
+    int port,
+    int reg,
+    int data)
+
+{
+   AL_SendOutputToPort_OPL3LPT(port, reg, data);
 }
 
 /*---------------------------------------------------------------------
@@ -1141,29 +1126,7 @@ int AL_DetectFM(
     void)
 
 {
-   int status1;
-   int status2;
-   int i;
-
-   AL_SendOutputToPort(ADLIB_PORT, 4, 0x60); // Reset T1 & T2
-   AL_SendOutputToPort(ADLIB_PORT, 4, 0x80); // Reset IRQ
-
-   status1 = inp(ADLIB_PORT);
-
-   AL_SendOutputToPort(ADLIB_PORT, 2, 0xff); // Set timer 1
-   AL_SendOutputToPort(ADLIB_PORT, 4, 0x21); // Start timer 1
-
-   for (i = 100; i > 0; i--)
-   {
-      inp(ADLIB_PORT);
-   }
-
-   status2 = inp(ADLIB_PORT);
-
-   AL_SendOutputToPort(ADLIB_PORT, 4, 0x60);
-   AL_SendOutputToPort(ADLIB_PORT, 4, 0x80);
-
-   return (((status1 & 0xe0) == 0x00) && ((status2 & 0xe0) == 0xc0));
+   return 1;
 }
 
 /*---------------------------------------------------------------------

--- a/FASTDOOM/ns_sbmus.c
+++ b/FASTDOOM/ns_sbmus.c
@@ -1158,50 +1158,11 @@ int AL_Init(int soundcard)
    BLASTER_CONFIG Blaster;
    int status = BLASTER_Ok;
 
-   AL_Stereo = FALSE;
-   AL_OPL3 = FALSE;
-   AL_LeftPort = 0x388;
-   AL_RightPort = 0x388;
-
-   switch (soundcard)
-   {
-   case ProAudioSpectrum:
-   case SoundMan16:
-      AL_OPL3 = TRUE;
-      AL_Stereo = TRUE;
-      AL_LeftPort = 0x388;
-      AL_RightPort = 0x38A;
-      break;
-
-   case SoundBlaster:
-      status = BLASTER_GetCardSettings(&Blaster);
-      if (status != BLASTER_Ok)
-      {
-         status = BLASTER_GetEnv(&Blaster);
-         if (status != BLASTER_Ok)
-         {
-            break;
-         }
-      }
-
-      switch (Blaster.Type)
-      {
-      case SBPro2:
-      case SB16:
-         AL_OPL3 = TRUE;
-         AL_Stereo = TRUE;
-         AL_LeftPort = Blaster.Address;
-         AL_RightPort = Blaster.Address + 2;
-         break;
-
-      case SBPro:
-         AL_Stereo = TRUE;
-         AL_LeftPort = Blaster.Address;
-         AL_RightPort = Blaster.Address + 2;
-         break;
-      }
-      break;
-   }
+   AL_Stereo = TRUE;
+   AL_OPL3 = TRUE;
+   // LPT PORTS
+   AL_LeftPort = 0x378;
+   AL_RightPort = 0x378;
 
    AL_CalcPitchInfo();
    AL_Reset();

--- a/FASTDOOM/ns_sbmus.h
+++ b/FASTDOOM/ns_sbmus.h
@@ -13,7 +13,7 @@ enum AL_Errors
 //#define AL_DefaultPitchBendRange 2
 #define AL_DefaultPitchBendRange 200
 
-#define ADLIB_PORT 0x388
+#define ADLIB_PORT 0x378
 
 void AL_SendOutputToPort(int port, int reg, int data);
 void AL_SendOutputToPort_OPL2LPT(int port, int reg, int data);

--- a/FASTDOOM/p_sight.c
+++ b/FASTDOOM/p_sight.c
@@ -262,9 +262,9 @@ byte P_CheckSight(mobj_t *t1, mobj_t *t2)
     // First check for trivial rejection.
 
     // Determine subsector entries in REJECT table.
-    s1 = (t1->subsector->sector - sectors);
-    s2 = (t2->subsector->sector - sectors);
-    pnum = s1 * numsectors + s2;
+    pnum = Div96((int)t1->subsector->sector - (int)sectors);
+    pnum *= numsectors;
+    pnum += Div96((int)t2->subsector->sector - (int)sectors);
     bytenum = pnum >> 3;
     bitnum = 1 << (pnum & 7);
 

--- a/FASTDOOM/p_sight.c
+++ b/FASTDOOM/p_sight.c
@@ -262,9 +262,9 @@ byte P_CheckSight(mobj_t *t1, mobj_t *t2)
     // First check for trivial rejection.
 
     // Determine subsector entries in REJECT table.
-    pnum = Div96((int)t1->subsector->sector - (int)sectors);
-    pnum *= numsectors;
-    pnum += Div96((int)t2->subsector->sector - (int)sectors);
+    s1 = (t1->subsector->sector - sectors);
+    s2 = (t2->subsector->sector - sectors);
+    pnum = s1 * numsectors + s2;
     bytenum = pnum >> 3;
     bitnum = 1 << (pnum & 7);
 
@@ -294,3 +294,4 @@ byte P_CheckSight(mobj_t *t1, mobj_t *t2)
     // the head node is the last node output
     return P_CrossBSPNode(firstnode);
 }
+

--- a/FASTDOOM/p_sight.c
+++ b/FASTDOOM/p_sight.c
@@ -294,4 +294,3 @@ byte P_CheckSight(mobj_t *t1, mobj_t *t2)
     // the head node is the last node output
     return P_CrossBSPNode(firstnode);
 }
-


### PR DESCRIPTION
Now it's just rewiring any Adlib call to OPL3LPT. Proper implementation implies modifying FDSETUP code.